### PR TITLE
Change role name for compute

### DIFF
--- a/environments/contrail/install_vrouter_kmod.yaml
+++ b/environments/contrail/install_vrouter_kmod.yaml
@@ -213,7 +213,7 @@ resources:
                 fi
               fi
             fi
-            if [[ `echo $role |awk -F"-" '{print $2}'` == "novacompute" || `hostname |awk -F"-" '{print $2}'` == "contrailtsn" ]]; then 
+            if [[ `echo $role |awk -F"-" '{print $2}'` == "compute" || `hostname |awk -F"-" '{print $2}'` == "contrailtsn" ]]; then
               if [[ ${contrail_repo} ]]; then
                 yum install -y contrail-vrouter-utils
               fi


### PR DESCRIPTION
The name expected in script was novacompute. In Newton, is now compute.

Tested and works with contrail-tripleo-heat-template-3.2.3.2-6 and
newton.

Co-Authored-By: Christine Mayap Kamga <christine.mayapkamga@gmail.com>

Signed-off-by: Cyril Lopez <cylopez@redhat.com>

fix #13 