### PR TITLE
Enabling core creation on overcloud roles

### DIFF
--- a/environments/contrail/install_vrouter_kmod.yaml
+++ b/environments/contrail/install_vrouter_kmod.yaml
@@ -105,6 +105,10 @@ resources:
               rsync -a /usr/share/contrail-tripleo-puppet/ /usr/share/openstack-puppet/modules/tripleo/
             fi
             mkdir /var/crashes
+            chmod -R 755 /var/crashes
+            ulimit -c unlimited
+            echo "kernel.core_pattern = /var/crashes/core.%e.%p.%h.%t" >> /etc/sysctl.conf
+            sysctl -p
             echo $hostname_map > /tmp/hostnamemap
             hname_list=(`cat /tmp/hostnamemap |tr -d ' '|tr -d '{'| tr -d '}' |tr ',' ' '`)
             for rolename in "${hname_list[@]}"
@@ -129,7 +133,6 @@ resources:
               ip route >> $trace_file 2>&1
               echo "vm.nr_hugepages = ${dpdk_hugepages}" >> /etc/sysctl.conf
               echo "vm.max_map_count = 128960" >> /etc/sysctl.conf
-              echo "kernel.core_pattern = /var/crashes/core.%e.%p.%h.%t" >> /etc/sysctl.conf
               echo "net.ipv4.tcp_keepalive_time = 5" >> /etc/sysctl.conf
               echo "net.ipv4.tcp_keepalive_probes = 5" >> /etc/sysctl.conf
               echo "net.ipv4.tcp_keepalive_intvl = 1" >> /etc/sysctl.conf


### PR DESCRIPTION
/var/crashes was not created on the overcloud roles. As a result,
core files could not be written. This commit includes these changes:
1. create /var/crashes
2. provide permissions
3. set kernel core pattern
4. set ulimit value
5. 'sysctl -p' to load new values

Fixes bug: 1706838