### PR TITLE
Enabling core creation on overcloud nodes

### DIFF
--- a/extraconfig/pre_network/contrail/compute_pre_network.yaml
+++ b/extraconfig/pre_network/contrail/compute_pre_network.yaml
@@ -86,6 +86,11 @@ resources:
         bond_mode=$bond_mode
         bond_policy=$bond_policy
         vlan_parent=$vlan_parent
+        mkdir /var/crashes
+        chmod -R 755 /var/crashes
+        ulimit -c unlimited
+        echo "kernel.core_pattern = /var/crashes/core.%e.%p.%h.%t" >> /etc/sysctl.conf
+        sysctl -p
         if [[ ${contrail_repo} ]]; then
           yum install -y contrail-vrouter-utils
         fi

--- a/extraconfig/pre_network/contrail/contrail_dpdk_pre_network.yaml
+++ b/extraconfig/pre_network/contrail/contrail_dpdk_pre_network.yaml
@@ -125,10 +125,15 @@ resources:
         mkdir /var/crashes
         echo "vm.nr_hugepages = $dpdk_hugepages" >> /etc/sysctl.conf
         echo "vm.max_map_count = 128960" >> /etc/sysctl.conf
+        mkdir /var/crashes
+        chmod -R 755 /var/crashes
+        ulimit -c unlimited
+        echo "kernel.core_pattern = /var/crashes/core.%e.%p.%h.%t" >> /etc/sysctl.conf
         echo "kernel.core_pattern = /var/crashes/core.%e.%p.%h.%t" >> /etc/sysctl.conf
         echo "net.ipv4.tcp_keepalive_time = 5" >> /etc/sysctl.conf
         echo "net.ipv4.tcp_keepalive_probes = 5" >> /etc/sysctl.conf
         echo "net.ipv4.tcp_keepalive_intvl = 1" >> /etc/sysctl.conf
+        sysctl -p
         /sbin/sysctl --system || echo /sbin/sysctl --system failed err=$? >> $trace_file
         modprobe uio || echo modprobe uio failed >> $trace_file
         pci_address=`ethtool -i ${phy_int} |grep bus-info| awk '{print $2}' |tr -d ' '`


### PR DESCRIPTION
In 4.x, this is needed only on the compute nodes
/var/crashes was not created on the overcloud roles. As a result,
core files could not be written. This commit includes these changes:
1. create /var/crashes
2. provide permissions
3. set kernel core pattern
4. set ulimit value
5. 'sysctl -p' to load new values

Fixes bug: 1706838