### PR TITLE
Forcing vlan-physical-interface to come up

### DIFF
--- a/environments/contrail/install_vrouter_kmod.yaml
+++ b/environments/contrail/install_vrouter_kmod.yaml
@@ -289,6 +289,7 @@ resources:
                   vif --create vhost0 --mac $DEV_MAC
                   vif --add ${phy_int} --mac $DEV_MAC --vrf 0 --vhost-phys --type physical
                   vif --add vhost0 --mac $DEV_MAC --vrf 0 --type vhost --xconnect ${phy_int}
+                  ifconfig ${phy_int} up
                   ip link set vhost0 up
                   return 0
               }


### PR DESCRIPTION
Saw this behavior in RHEL 7.4 + Contrail 3.2 consistently.
vhost0 was tied to vlan20, and vlan20 was in down state
Because of this, provisioning failed every time. 
Provisioning goes through successfully after making
this change.

Fixes bug: 1711723