### PR TITLE
Down slave iface before assign a master.

### DIFF
--- a/extraconfig/pre_network/contrail/compute_pre_network.yaml
+++ b/extraconfig/pre_network/contrail/compute_pre_network.yaml
@@ -79,6 +79,11 @@ resources:
       - name: vlan_parent
       config: |
         #!/bin/bash
+        export LOGFILE=/tmp/contrail_trace_full.txt
+        exec > >(tee -a $LOGFILE)
+        exec 2>&1
+        echo "=================== $(date) ==================="
+        set -xv
         contrail_repo=$contrail_repo
         phy_int=$phy_int
         bond_int=$bond_int
@@ -126,7 +131,7 @@ resources:
             vif --create vhost0 --mac $DEV_MAC
             vif --add ${phy_int} --mac $DEV_MAC --vrf 0 --vhost-phys --type physical
             vif --add vhost0 --mac $DEV_MAC --vrf 0 --type vhost --xconnect ${phy_int}
-            ip link set vhost0 up
+            ip link set dev vhost0 up
             return 0
         }
         if [[ ${bond_int} ]]; then
@@ -134,8 +139,10 @@ resources:
            ip link add name ${bond_int} type bond
            echo ${bond_mode} > /sys/class/net/${bond_int}/bonding/mode
            echo ${bond_policy} > /sys/class/net/${bond_int}/bonding/xmit_hash_policy
+           ip link set dev ${bond_int} up
            for member in ${bond_int_member_list}; do
-               ip link set dev $member master ${bond_int}
+               ip link set dev ${member} down
+               ip link set dev ${member} master ${bond_int}
            done
         fi
         if [[ ${vlan_parent} ]]; then

--- a/extraconfig/pre_network/contrail/contrail_dpdk_pre_network.yaml
+++ b/extraconfig/pre_network/contrail/contrail_dpdk_pre_network.yaml
@@ -97,6 +97,11 @@ resources:
       - name: dpdk_coremask
       config: |
         #!/bin/bash
+        export LOGFILE=/tmp/contrail_trace_full.txt
+        exec > >(tee -a $LOGFILE)
+        exec 2>&1
+        echo "=================== $(date) ==================="
+        set -xv
         contrail_repo=$contrail_repo
         phy_int=$phy_int
         bond_int=$bond_int
@@ -107,20 +112,6 @@ resources:
         vrouter_gateway=$vrouter_gateway
         dpdk_hugepages=$dpdk_hugepages
         dpdk_coremask=$dpdk_coremask
-        trace_file=/tmp/contrail.trace
-        date > $trace_file
-        echo phy_int=$phy_int \
-          bond_int=$bond_int \
-          bond_int_members=$bond_int_members \
-          bond_mode=$bond_mode \
-          bond_policy=$bond_policy \
-          vlan_parent=$vlan_parent \
-          contrail_repo=$contrail_repo \
-          vrouter_gateway=$vrouter_gateway \
-          dpdk_hugepages=$dpdk_hugepages \
-          dpdk_coremask=$dpdk_coremask >> $trace_file
-        ifconfig >> $trace_file 2>&1
-        ip route >> $trace_file 2>&1
         echo "127.0.0.1    `hostname`" >> /etc/hosts
         mkdir /var/crashes
         echo "vm.nr_hugepages = $dpdk_hugepages" >> /etc/sysctl.conf
@@ -134,8 +125,8 @@ resources:
         echo "net.ipv4.tcp_keepalive_probes = 5" >> /etc/sysctl.conf
         echo "net.ipv4.tcp_keepalive_intvl = 1" >> /etc/sysctl.conf
         sysctl -p
-        /sbin/sysctl --system || echo /sbin/sysctl --system failed err=$? >> $trace_file
-        modprobe uio || echo modprobe uio failed >> $trace_file
+        /sbin/sysctl --system
+        modprobe uio
         pci_address=`ethtool -i ${phy_int} |grep bus-info| awk '{print $2}' |tr -d ' '`
         if [[ ${vlan_parent} ]]; then
            pci_address=`ethtool -i ${vlan_parent} |grep bus-info| awk '{print $2}' |tr -d ' '`
@@ -176,7 +167,7 @@ resources:
         VLAN=yes
         PHYSDEV=${vlan_parent}
         EOF
-          ifup ${phy_int} || echo ifup ${phy_int} failed res=$? >> $trace_file
+          ifup ${phy_int}
         fi
         # save ip and mask before starting services, otherwise they are always emty
         # since dpdk device becomes non-network devices
@@ -187,13 +178,12 @@ resources:
         ip=`ifconfig ${phy_int} | grep 'inet ' | awk '{print $2}'`
         mask=`ifconfig ${phy_int} | grep 'inet ' | awk '{print $4}'`
         mac=`ip link sh dev ${phy_int} | grep link/ether|awk '{print $2}' | tr -d ' '`
-        echo  "${phy_int} ip=$ip mask=$mask def_gw=$def_gw mac=$mac" >> $trace_file
         # install vrouter packages and prepare configs
         if [[ ${contrail_repo} ]]; then
           yum install -y \
             contrail-vrouter-utils \
             contrail-vrouter-dpdk \
-            contrail-vrouter-dpdk-init || echo contrail packages installation failed err=$? >> $trace_file
+            contrail-vrouter-dpdk-init
         fi
         cat <<EOF > /etc/contrail/agent_param
         LOG=/var/log/contrail.log
@@ -227,31 +217,25 @@ resources:
         echo $mac > /etc/contrail/dpdk_mac
         sed -i "s#^command=#&/bin/taskset ${dpdk_coremask} #" /etc/contrail/supervisord_vrouter_files/contrail-vrouter-dpdk.ini
         if sestatus | grep -i "Current mode" | grep -q enforcing ; then
-          echo systemctl daemon-reexec... >> $trace_file
           systemctl daemon-reexec
-          echo systemctl daemon-reexec res=$? >> $trace_file
         fi
-        ldconfig || echo ldconfig failed res=$? >> $trace_file
+        ldconfig
         # start contrail services assign mac to vhost0 and up the vhost0 interface
-        systemctl start supervisor-vrouter || echo lsystemctl start supervisor-vrouter failed res=$? >> $trace_file
+        systemctl start supervisor-vrouter
         sleep 10
-        ip link set dev vhost0 address $mac || echo ip link set dev vhost0 address $mac failed res=$? >> $trace_file
-        ip link set vhost0 up || echo ip link set vhost0 up res=$? >> $trace_file
+        ip link set dev vhost0 address $mac
+        ip link set dev vhost0 up
         # assign ip to vhost0
         if [[ -n "$ip" && -n "$mask" ]]; then
-          ip address delete $ip/$mask dev ${phy_int} || echo ip address delete $ip/$mask dev ${phy_int} failed res=$? >> $trace_file
-          ip address add $ip/$mask dev vhost0 || echo ip address add $ip/$mask dev vhost0 failed res=$? >> $trace_file
+          ip address delete $ip/$mask dev ${phy_int}
+          ip address add $ip/$mask dev vhost0
           if [[ $def_gw ]]; then
-            ip route add default via $def_gw || echo ip route add default via $def_gw failed res=$? >> $trace_file
-          else
-            echo ${phy_int} has no gateway >> $trace_file
+            ip route add default via $def_gw
           fi
-        else
-          echo ${phy_int} has no IP >> $trace_file
         fi
-        echo finishing... >> $trace_file
-        ifconfig >> $trace_file 2>&1
-        ip route >> $trace_file 2>&1
+        echo finishing...
+        ifconfig
+        ip route
 
 outputs:
   # This means get_resource from the parent template will get the userdata, see:


### PR DESCRIPTION
If iface id up the assign a master to iface fails with operation is not permitted error.
Bring up bond iface before assiging slaves. If assign slave before bringing up the bond the slaves doen get equal MAC.
Unify form of ip link .. up command.

Enable extended tracing for inserting kmod script.