### PR TITLE
Adding tsn-specific-hieradata file to solve EVPN VXLAN Provisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,3 +613,92 @@ openstack overcloud deploy --templates tripleo-heat-templates/ \
   -e tripleo-heat-templates/extraconfig/pre_deploy/rhel-registration/rhel-registration-resource-registry.yaml \
   --libvirt-type qemu
 ```
+
+# DPDK special
+## get dpdk tripleo-heat-templates
+```
+git clone http://github.com/Juniper/contrail-tripleo-heat-templates -b dpdk4
+cp contrail-tripleo-heat-templates/* ~/tripleo-heat-templates
+```
+
+## get contrail dpdk packages
+Ask Michael
+
+## extract contrail dpdk packages to webserver
+```
+cp contrail-3.2.2.0-33-dpdk.tgz /var/www/html/contrail
+cd /var/www/html/contrail && tar zxvf contrail-3.2.2.0-33-dpdk.tgz
+cd
+```
+
+## virt-customize compute overcloud image
+For DPDK the compute image must be modified. User/password for RH subscription must be provided:
+```
+cd ~/images
+cp overcloud-full.qcow2 overcloud-full-dpdk.qcow2
+virt-customize  -a overcloud-full-dpdk.qcow2 \
+  --sm-credentials $RH_USER:password:$RH_PASSWORD --sm-register --sm-attach auto \
+  --run-command 'subscription-manager repos --enable=rhel-7-server-rpms --enable=rhel-7-server-extras-rpms --enable=rhel-7-server-rh-common-rpms --enable=rhel-ha-for-rhel-7-server-rpms --enable=rhel-7-server-openstack-10-rpms' --enable=rhel-7-server-openstack-10-devtools-rpms \
+  --copy-in /tmp/dpdk/contrail.repo:/etc/yum.repos.d \
+  --run-command 'yum install -y contrail-vrouter-utils contrail-vrouter-dpdk contrail-vrouter-dpdk-init contrail-vrouter-dpdk-kernel-modules supervisor contrail-vrouter-agent contrail-nodemgr contrail-setup contrail-tripleo-puppet puppet-contrail python-contrail' \
+  --run-command 'mkdir -p /lib/modules/`uname -r`/weak-updates' \
+  --run-command 'cp `find /lib/modules -name rte_kni.ko |tail -1` /lib/modules/`uname -r`/weak-updates' \
+  --run-command 'cp `find /lib/modules -name igb_uio.ko |tail -1` /lib/modules/`uname -r`/weak-updates' \
+  --run-command 'echo "#!/bin/sh" >> /etc/sysconfig/modules/rte_kni.modules && echo "insmod /lib/modules/`uname -r`/weak-updates/rte_kni.ko" >> /etc/sysconfig/modules/rte_kni.modules && chmod +x /etc/sysconfig/modules/rte_kni.modules' \
+  --run-command 'echo "#!/bin/sh" >> /etc/sysconfig/modules/igb_uio.modules && echo "insmod /lib/modules/`uname -r`/weak-updates/igb_uio.ko" >> /etc/sysconfig/modules/igb_uio.modules && chmod +x /etc/sysconfig/modules/igb_uio.modules' \
+  --run-command 'depmod -a' \
+  --run-command 'git clone https://github.com/Juniper/contrail-nova-vif-driver' \
+  --run-command 'cd contrail-nova-vif-driver && python setup.py install' \
+  --run-command 'rm -rf /etc/yum.repos.d/contrail.repo' \
+  --run-command 'subscription-manager unregister' \
+  --selinux-relabel
+```
+
+## upload image to glance
+```
+glance image-create --name overcloud-full-dpdk --container-format bare --disk-format qcow2 --file overcloud-full-dpdk.qcow2
+openstack image set overcloud-full-dpdk --property kernel_id=`glance image-list |grep bm-deploy-kernel |awk '{print $2}'` --property ramdisk_id=glance image-list |grep bm-deploy-ramdisk |awk '{print $2}'
+```
+
+## profile node for dpdk
+DPDK_NODE_UUID = uuid of dpdk node
+```
+ironic node-update $DPDK_NODE_UUID replace properties/capabilities=profile:contrail-dpdk,cpu_hugepages:true,cpu_txt:true,boot_option:local,cpu_aes:true,cpu_vt:true,cpu_hugepages_1g:true
+openstack flavor create contrail-dpdk --ram 4096 --vcpus 1 --disk 40
+openstack flavor set --property "capabilities:boot_option"="local" --property "capabilities:profile"="contrail-dpdk" contrail-dpdk
+```
+
+## deploy
+```
+openstack overcloud deploy --stack dpdk --templates tripleo-heat-templates/ \
+  --roles-file tripleo-heat-templates/environments/contrail/roles_data.yaml \
+  -e tripleo-heat-templates/environments/puppet-pacemaker.yaml \
+  -e tripleo-heat-templates/environments/contrail/contrail-services.yaml \
+  -e tripleo-heat-templates/environments/contrail/network-isolation.yaml \
+  -e tripleo-heat-templates/environments/contrail/contrail-net-dpdk-bond-vlan.yaml \
+  -e tripleo-heat-templates/environments/contrail/ips-from-pool-all.yaml \
+  -e tripleo-heat-templates/environments/network-management.yaml \
+  -e tripleo-heat-templates/extraconfig/pre_deploy/rhel-registration/environment-rhel-registration.yaml \
+  -e tripleo-heat-templates/extraconfig/pre_deploy/rhel-registration/rhel-registration-resource-registry.yaml
+ ```
+
+
+# TSN special
+
+In case of EVPN VXLAN Provisioning when more than 2 TSN nodes are present, user should provide per TSN node specific hiera data with "contrail::vrouter::tsn_servers" containing a pair of TSNs.
+
+```
+vi tripleo-heat-templates/environments/contrail/contrail-tsn-servers.yaml
+```
+
+## deploy
+```
+openstack overcloud deploy --templates tripleo-heat-templates/ \
+  --roles-file tripleo-heat-templates/environments/contrail/roles_data_contrail.yaml \
+  -e .tripleo/environments/deployment-artifacts.yaml \
+  -e tripleo-heat-templates/environments/contrail/contrail-services.yaml \
+  -e tripleo-heat-templates/environments/contrail/contrail-net-single.yaml \
+  -e contrail_controller_vip_env.yaml \
+  -e misc_opts.yaml \
+  -e tripleo-heat-templates/environments/contrail/contrail-tsn-servers.yaml
+```

--- a/blueprint_ospd.md
+++ b/blueprint_ospd.md
@@ -74,7 +74,7 @@ cp -r /usr/share/contrail-tripleo-heat-templates/extraconfig ~/tripleo-heat-temp
 cp -r /usr/share/contrail-tripleo-heat-templates/network ~/tripleo-heat-templates
 ```
 
-### contrail services (repo url etc.)
+### contrail services parameters (contrail version, repo url etc.)
 ```
 vi ~/tripleo-heat-templates/environments/contrail/contrail-services.yaml
 ```

--- a/environments/contrail/contrail-services.yaml
+++ b/environments/contrail/contrail-services.yaml
@@ -34,6 +34,7 @@ parameter_defaults:
     ContrailTsnNetwork: internal_api
     ContrailVrouterNetwork: internal_api
     ContrailDpdkNetwork: internal_api
+  ContrailVersion: 4
   ContrailRepo: http://192.168.24.1/contrail
   ContrailControlManageNamed: true
   EnablePackageInstall: true

--- a/environments/contrail/contrail-tsn-servers.yaml
+++ b/environments/contrail/contrail-tsn-servers.yaml
@@ -1,0 +1,26 @@
+# This file must be used in case if there are more TSNs then it is needed to use ‘per-node hiera data’
+# 
+# The NodeDataLookup section is organized as:
+## {"NODE-1-UUID": {"Node-1-hiera-key-1": "Node-1-hiera-value-1", "Node-1-hiera-key-2": "Node-1-hiera-value-2"},
+##  "NODE-2-UUID": {"Node-2-hiera-key-1": "Node-2-hiera-value-1", "Node-2-hiera-key-2": "Node-2-hiera-value-2"}}
+#
+# The UUID of each node can be obtained by issuing "openstack baremetal introspection data save <ironic-node-uuid> | jq .extra.system.product.uuid"
+#
+## HOW TO POPULATE NodeDataLookup:
+# {"Contrail-TSN-1-UUID": {"contrail::vrouter::tsn_servers": ['Contrail-TSN-ACTIVE-IP','Contrail-TSN-BACKUP-IP']},
+#  "Contrail-TSN-2-UUID": {"contrail::vrouter::tsn_servers": ['Contrail-TSN-ACTIVE-IP','Contrail-TSN-BACKUP-IP']},
+#  "Contrail-TSN-3-UUID": {"contrail::vrouter::tsn_servers": ['Contrail-TSN-ACTIVE-IP','Contrail-TSN-BACKUP-IP']},
+#  "Contrail-TSN-4-UUID": {"contrail::vrouter::tsn_servers": ['Contrail-TSN-ACTIVE-IP','Contrail-TSN-BACKUP-IP']}} 
+# 
+# The sample UUID's/IP's/Names provided below are from a working sample. 
+# Keep the resource_registry section as it is, and make changes to the NodeDataLookup section according to your overcloud deployment.
+#
+resource_registry:
+  OS::TripleO::ContrailTSNExtraConfigPre: ../../puppet/extraconfig/pre_deploy/per_node.yaml
+
+parameter_defaults:
+  NodeDataLookup: |
+    {"16CDCDA6-B096-46C7-A646-B188183E39F4": {"contrail::vrouter::tsn_servers": ['10.0.0.1','10.0.0.2']},
+     "99FD12A9-191C-41B3-BF6B-3CE30C63CC01": {"contrail::vrouter::tsn_servers": ['10.0.0.1','10.0.0.2']},
+     "D4B82082-5D64-4674-93AB-7377B6311820": {"contrail::vrouter::tsn_servers": ['10.0.0.3','10.0.0.4']},
+     "AB15DEA1-89B8-4621-9F79-5A6AE25BCF93": {"contrail::vrouter::tsn_servers": ['10.0.0.3','10.0.0.4']}}


### PR DESCRIPTION
In case of EVPN VXLAN Provisioning when more than 2 TSN nodes are
 present, user should provide per TSN node specific hiera data with
 "contrail::vrouter::tsn_servers" containing a pair of TSNs.