### PR TITLE
add needed repro to osp10 Heat template

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,8 @@ vi ~/tripleo-heat-templates/environments/contrail/ips-from-pool-all.yaml
 ```
 
 ## provide subscription mgr credentials (rhel_reg_password, rhel_reg_pool_id, rhel_reg_repos, rhel_reg_user and method)
+### OSP10
+Make also sure you add the repro "rhel-7-server-openstack-10-devtools-rpms" to rhel_reg_repos as it's needed for vRouter installation
 ```
 vi ~/tripleo-heat-templates/extraconfig/pre_deploy/rhel-registration/environment-rhel-registration.yaml
 ```


### PR DESCRIPTION
keine ahnung ob das auch aehnlich fuer OSP11 ist.
Bei mir hat er die installation ohne diese packet nicht durchfuehren koennen. Da fehlen wohl sachen wie openstack-status die die redhat buben jetzt in dieses packet abgeschoben haben.