### PR TITLE
Ensuring that link is set up on the created VLAN interface.

### DIFF
--- a/extraconfig/pre_network/contrail/compute_pre_network.yaml
+++ b/extraconfig/pre_network/contrail/compute_pre_network.yaml
@@ -148,6 +148,7 @@ resources:
         if [[ ${vlan_parent} ]]; then
             vlanId=`echo ${phy_int} | awk -F"vlan" '{print $2}'`
             ip link add name ${phy_int} link ${vlan_parent} type vlan id ${vlanId}
+            ip link set up dev ${phy_int}
         fi
         if [[ ${contrail_repo} ]]; then
           yumdownloader contrail-vrouter --destdir /tmp


### PR DESCRIPTION
By default newly created interface gets link down. As a result vhost0 can't be reached over InternalApi network and deployment fails. This commit sets the link up once VLAN interface is created
