### PR TITLE
Removes manila-generic-config from TripleO

### DIFF
--- a/environments/contrail/roles_data_contrail.yaml
+++ b/environments/contrail/roles_data_contrail.yaml
@@ -96,7 +96,6 @@
     - OS::TripleO::Services::GnocchiStatsd
     - OS::TripleO::Services::ManilaApi
     - OS::TripleO::Services::ManilaScheduler
-    - OS::TripleO::Services::ManilaBackendGeneric
     - OS::TripleO::Services::ManilaBackendNetapp
     - OS::TripleO::Services::ManilaBackendCephFs
     - OS::TripleO::Services::ManilaShare


### PR DESCRIPTION
Closes-Bug: #1773030