### PR TITLE
Ignore ssl errors if internal_tls_enabled is false

### DIFF
--- a/docker/services/contrail/contrail-webui.yaml
+++ b/docker/services/contrail/contrail-webui.yaml
@@ -110,7 +110,8 @@ outputs:
                           - ' '
                           - - 'crl-file'
                             - {get_param: InternalTLSCRLPEMFile}
-                      - null
+                      - - 'ssl'
+                        - 'verify none'
       docker_config:
         step_4:
           get_attr: [ContrailRedis, role_data, docker_config, step_4]


### PR DESCRIPTION
SSL backends for WebUI are responding with not trusted certificates.
Those need to be ignored.