### PR TITLE
Dont use depricated params in new contrail files.

### DIFF
--- a/environments/contrail/contrail-services.yaml
+++ b/environments/contrail/contrail-services.yaml
@@ -7,7 +7,7 @@ parameter_defaults:
     ContrailControlNetwork: tenant
     ContrailWebuiNetwork: internal_api
     ContrailVrouterNetwork: tenant
-  OvercloudControlFlavor: control
+  OvercloudControllerFlavor: control
   OvercloudContrailControllerFlavor: contrail-controller
   OvercloudComputeFlavor: compute
   OvercloudContrailDpdkFlavor: compute-dpdk
@@ -40,5 +40,5 @@ parameter_defaults:
 #  NovaPCIPassthrough:
 #    - devname: "ens2f1"
 #      physical_network: "sriov1"
-#  ContrailSriovNumVFs: ["ens2f1:7"] 
+#  ContrailSriovNumVFs: ["ens2f1:7"]
 #  ContrailSriovHugepages1GB: 10

--- a/environments/contrail/contrail-services_aio.yaml
+++ b/environments/contrail/contrail-services_aio.yaml
@@ -24,7 +24,7 @@ parameter_defaults:
     ContrailControlNetwork: tenant
     ContrailWebuiNetwork: internal_api
     ContrailVrouterNetwork: tenant
-  OvercloudControlFlavor: control
+  OvercloudControllerFlavor: control
   OvercloudContrailControllerFlavor: contrail-controller
   OvercloudComputeFlavor: compute
   OvercloudContrailDpdkFlavor: compute-dpdk

--- a/roles/ContrailDpdk.yaml
+++ b/roles/ContrailDpdk.yaml
@@ -12,11 +12,6 @@
     - Tenant
     - Storage
   HostnameFormatDefault: '%stackname%-contraildpdk-%index%'
-  # Deprecated & backward-compatible values (FIXME: Make parameters consistent)
-  # Set uses_deprecated_params to True if any deprecated params are used.
-  uses_deprecated_params: True
-  deprecated_param_metadata: 'NovaComputeServerMetadata'
-  deprecated_param_scheduler_hints: 'NovaComputeSchedulerHints'
   disable_upgrade_deployment: True
   ServicesDefault:
     - OS::TripleO::Services::Aide

--- a/roles_data_contrail_aio.yaml
+++ b/roles_data_contrail_aio.yaml
@@ -273,11 +273,6 @@
     - Tenant
     - Storage
   HostnameFormatDefault: '%stackname%-contraildpdk-%index%'
-  # Deprecated & backward-compatible values (FIXME: Make parameters consistent)
-  # Set uses_deprecated_params to True if any deprecated params are used.
-  uses_deprecated_params: True
-  deprecated_param_metadata: 'NovaComputeServerMetadata'
-  deprecated_param_scheduler_hints: 'NovaComputeSchedulerHints'
   disable_upgrade_deployment: True
   ServicesDefault:
     - OS::TripleO::Services::Aide
@@ -329,11 +324,6 @@
     - Tenant
     - Storage
   HostnameFormatDefault: '%stackname%-contrailsriov-%index%'
-  # Deprecated & backward-compatible values (FIXME: Make parameters consistent)
-  # Set uses_deprecated_params to True if any deprecated params are used.
-  uses_deprecated_params: True
-  deprecated_param_metadata: 'NovaComputeServerMetadata'
-  deprecated_param_scheduler_hints: 'NovaComputeSchedulerHints'
   disable_upgrade_deployment: True
   ServicesDefault:
     - OS::TripleO::Services::Aide


### PR DESCRIPTION
This is reverting of:
commit 328fd1e0300b528a59bed4cde66f260c7177040e
Author: Maciej Relewicz <mrelewicz@juniper.net>
Date:   Wed Jun 20 14:37:44 2018 +0200

    should be OvercloudControlFlavor not OvercloudControllerFlavor