### PR TITLE
Update ContrailController.yaml

### DIFF
--- a/roles/ContrailController.yaml
+++ b/roles/ContrailController.yaml
@@ -28,6 +28,7 @@
     - OS::TripleO::Services::Snmp
     - OS::TripleO::Services::Sshd
     - OS::TripleO::Services::Timezone
+    - OS::TripleO::Services::TripleoFirewall
     - OS::TripleO::Services::TripleoPackages
     - OS::TripleO::Services::ContrailConfigDatabase
     - OS::TripleO::Services::ContrailConfig


### PR DESCRIPTION
to enable iptables rules configuration on contrail nodes 
https://bugs.launchpad.net/juniperopenstack/+bug/1793165 